### PR TITLE
Fix for Neovim and ranger file browser

### DIFF
--- a/ftplugin/mail/CheckAttach.vim
+++ b/ftplugin/mail/CheckAttach.vim
@@ -203,9 +203,9 @@ fu! <SID>CheckAttach() "{{{2
     call winrestview(s:oldpos)
 endfu
 
-fu! <SID>ExternalFileBrowser(pat) "{{{2
-    " Call external File Browser
-    exe ':sil !' s:external_file_browser   a:pat
+fu! <SID>AppendAttachedFiles() "{{{2
+    " Append attached files to the header section
+
     " Force redrawing, so the screen doesn't get messed up
     redr!
     if filereadable(s:external_choosefile)
@@ -213,6 +213,28 @@ fu! <SID>ExternalFileBrowser(pat) "{{{2
 	    \ escape(v:val, " \t\\")'))
 	call delete(s:external_choosefile)
     endif
+endfu
+
+fu! <SID>ExternalFileBrowser(pat) "{{{2
+    " Call external File Browser
+    if has('nvim')
+	" Neovim requires that the file browser be opened in the neovim
+	" terminal. When the terminal with the filebrowser is opened,
+	" all other tabs are locked. When the terminal is closed,
+	" the tab is closed and back to the previous buffer -- we depend
+	" on that.
+	augroup TerminalClosed
+	    au BufEnter <buffer> :call <SID>AppendAttachedFiles()
+	    " Delete autocmd after it is executed
+	    au BufEnter <buffer> au!
+	augroup END
+	tabnew
+	execute 'terminal ' s:external_file_browser   a:pat
+    else
+	exe ':sil !' s:external_file_browser   a:pat
+	call <SID>AppendAttachedFiles()
+    endif
+
 endfu
 
 fu! <SID>AttachFile(...) "{{{2


### PR DESCRIPTION
`ranger` needs to run in a terminal, but `Neovim` does not
allow that for `:!` commands and `system()` function calls. Instead
it has an inbuilt terminal that must be invoked explicitly.

Fixes #13